### PR TITLE
Use load-grunt-tasks to simplify Gruntfile.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,9 @@
 /*global module:false*/
 module.exports = function(grunt) {
 
+    // Load grunt tasks
+    require('load-grunt-tasks')(grunt);
+
     // Project configuration.
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
@@ -82,14 +85,6 @@ module.exports = function(grunt) {
             }
         }
     });
-
-    grunt.loadNpmTasks('grunt-contrib-jshint');
-    grunt.loadNpmTasks('grunt-contrib-uglify');
-    grunt.loadNpmTasks('grunt-preprocess');
-    grunt.loadNpmTasks('grunt-plato');
-    grunt.loadNpmTasks('grunt-karma');
-    grunt.loadNpmTasks('grunt-karma-coveralls');
-    grunt.loadNpmTasks('grunt-indent');
 
     // Default task.
     grunt.registerTask('lint-test', 'jshint:test');

--- a/package.json
+++ b/package.json
@@ -22,16 +22,17 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.3",
-    "grunt-plato": "~1.0.0",
-    "grunt-preprocess": "~4.0.0",
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-uglify": "~0.4.0",
+    "grunt-indent": "~0.1.4",
     "grunt-karma": "~0.8.0",
     "grunt-karma-coveralls": "~2.4.0",
+    "grunt-plato": "~1.0.0",
+    "grunt-preprocess": "~4.0.0",
     "karma-coverage": "~0.2.0",
-    "mocha": "~1.17.1",
     "karma-mocha": "~0.1.1",
-    "grunt-indent": "~0.1.4",
-    "karma-phantomjs-launcher": "~0.1.2"
+    "karma-phantomjs-launcher": "~0.1.2",
+    "load-grunt-tasks": "^1.0.0",
+    "mocha": "~1.17.1"
   }
 }


### PR DESCRIPTION
- [load-grunt-tasks](https://github.com/sindresorhus/load-grunt-tasks) is cool
- npm sorts deps when you use the CLI. you must be hand-typing the deps?
